### PR TITLE
Bump to 2.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.5.0" %}
+{% set version = "2.6.0" %}
 
 package:
   name: python-coveralls
@@ -7,7 +7,7 @@ package:
 source:
   fn: python-coveralls-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/p/python-coveralls/python-coveralls-{{ version }}.tar.gz
-  md5: e66878a926b9d5dd04250e1a05080fbd
+  sha256: c0c9b246129bdf4c2e0f4a1b31962bb043b73030aa7a23f711561c1f6da8b0a5
 
 build:
   number: 0
@@ -25,7 +25,7 @@ requirements:
     - python
     - pyyaml
     - requests
-    - coverage ==3.7.1
+    - coverage ==4.0.3
     - six
     - sh
 


### PR DESCRIPTION
Please merge PRs ( https://github.com/conda-forge/python-coveralls-feedstock/pull/2 ) and ( https://github.com/conda-forge/python-coveralls-feedstock/pull/3 ) first.

Bumps to version `2.6.0`, which supports `coverage` version `4.0.3`.
